### PR TITLE
Feat : OAuth 유저 정보 저장 및 Token 발급 서비스 코드 구현

### DIFF
--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -41,8 +41,7 @@ dependencies {
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'org.mockito:mockito-core:5.8.0'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.domain.user.controller;
 
-import ForMZ.Server.domain.user.constant.UserConstant;
+import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.dto.MailReq;
 import ForMZ.Server.domain.user.dto.MailRes;
 import ForMZ.Server.domain.user.service.MailSenderService;
@@ -12,10 +12,7 @@ import ForMZ.Server.domain.user.dto.UserReq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static ForMZ.Server.domain.user.constant.UserConstant.AuthResponseMessage.*;
 
@@ -54,5 +51,11 @@ public class UserController {
         MailRes res = mailSenderService.joinEmail(mailReq.getEmail());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.create(HttpStatus.OK.value(), MAIL_SEND_SUCCESS.getMessage(), res));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> loginOAuth(@RequestParam("target") String target, @RequestParam("code") String code) {
+        LoginRes loginRes = userService.loginOAuth(target, code);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), loginRes));
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -5,8 +5,6 @@ import ForMZ.Server.domain.user.dto.MailReq;
 import ForMZ.Server.domain.user.dto.MailRes;
 import ForMZ.Server.domain.user.service.MailSenderService;
 import ForMZ.Server.domain.user.service.UserService;
-import ForMZ.Server.global.auth.jwt.dto.JwtToken;
-import ForMZ.Server.global.auth.jwt.dto.LoginReq;
 import ForMZ.Server.global.common.ResponseDto;
 import ForMZ.Server.domain.user.dto.UserReq;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +24,11 @@ public class UserController {
     /**
      * 일반 로그인
      */
-    @PostMapping("/login")
-    public ResponseEntity login(@RequestBody LoginReq loginReq){
-        JwtToken jwtToken = userService.Login(loginReq);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.create(HttpStatus.CREATED.value(), LOGIN_USER_SUCCESS.getMessage(), jwtToken));
-    }
+//    @PostMapping("/login")
+//    public ResponseEntity login(@RequestBody LoginReq loginReq){
+//        JwtToken jwtToken = userService.Login(loginReq);
+//        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.create(HttpStatus.CREATED.value(), LOGIN_USER_SUCCESS.getMessage(), jwtToken));
+//    }
 
     /**
      * 회원가입

--- a/Server/src/main/java/ForMZ/Server/domain/user/dto/LoginRes.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/dto/LoginRes.java
@@ -1,0 +1,15 @@
+package ForMZ.Server.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class LoginRes {
+    private String accessToken;
+
+    public static LoginRes toDto(String accessToken) {
+        return LoginRes.builder().accessToken(accessToken).build();
+    }
+}

--- a/Server/src/main/java/ForMZ/Server/domain/user/entity/SignType.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/entity/SignType.java
@@ -1,0 +1,8 @@
+package ForMZ.Server.domain.user.entity;
+
+public enum SignType {
+    NORMAL,
+    GOOGLE,
+    NAVER,
+    KAKAO
+}

--- a/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
@@ -65,4 +65,8 @@ public class User extends BaseEntity {
         this.password = password;
         this.nickName = nickName;
     }
+
+    public void updateOAuthInfo(OAuthUserInfo oAuthUserInfo) {
+        this.email = oAuthUserInfo.getEmail();
+    }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
@@ -1,30 +1,22 @@
 package ForMZ.Server.domain.user.entity;
 
-import ForMZ.Server.domain.bookmark.entity.Bookmark;
 import ForMZ.Server.domain.comment.entity.Comment;
-import ForMZ.Server.domain.commentLike.entity.CommentLike;
-import ForMZ.Server.domain.file.entity.File;
 import ForMZ.Server.domain.post.entity.Post;
-import ForMZ.Server.domain.postLike.entity.PostLike;
 import ForMZ.Server.global.entity.BaseEntity;
+import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.*;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User extends BaseEntity implements UserDetails {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -34,22 +26,21 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Column(nullable = false)
     private String nickName;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Builder.Default
-    private List<String> roles = new ArrayList<>();
+    @Column
+    private String profileImageUrl;
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private SignType signType;
 
     @Column
-    private String refreshToken;
+    private String socialId;
 
     @OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
     private List<Comment> comments = new ArrayList<>();
@@ -57,74 +48,20 @@ public class User extends BaseEntity implements UserDetails {
     @OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
     private List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
-    private List<Bookmark> bookmarks = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
-    private List<CommentLike> commentLikes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
-    private List<PostLike> postLikes = new ArrayList<>();
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profileImageId", referencedColumnName = "file_id")
-    private File profileImage;
-
-    public enum Role {
-        USER,
-        ADMIN
-    }
-
-    public enum SignType {
-        NORMAL,
-        GOOGLE,
-        KAKAO
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
+    // TODO : OAuth 로그인 유저의 닉네임 설정
+    public static User toEntity(OAuthUserInfo oAuthUserInfo) {
+        return User.builder()
+                .email(oAuthUserInfo.getEmail())
+//                .nickName()
+                .profileImageUrl(oAuthUserInfo.getImageUrl())
+                .signType(oAuthUserInfo.getSocialType())
+                .socialId(oAuthUserInfo.getSocialId())
+                .build();
     }
 
     public void updateProfile(String email, String password, String nickName, String profileImage) {
         this.email = email;
         this.password = password;
         this.nickName = nickName;
-        this.profileImage.updateFileUrl(profileImage);
-    }
-
-    /**
-     * UserDetails Implements
-     */
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public String getUsername() {
-        return this.email;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = @Index(columnList = "socialId, signType"))
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/entity/User.java
@@ -11,12 +11,11 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
+@Entity(name = "USERS")
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(indexes = @Index(columnList = "socialId, signType"))
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Server/src/main/java/ForMZ/Server/domain/user/repository/UserRepository.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package ForMZ.Server.domain.user.repository;
 
+import ForMZ.Server.domain.user.entity.SignType;
 import ForMZ.Server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findBySignTypeAndSocialId(SignType social, String socialId);
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/service/UserService.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/service/UserService.java
@@ -1,14 +1,14 @@
 package ForMZ.Server.domain.user.service;
 
+import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.dto.UserReq;
 import ForMZ.Server.domain.user.entity.User;
-import ForMZ.Server.global.auth.jwt.dto.JwtToken;
-import ForMZ.Server.global.auth.jwt.dto.LoginReq;
 
 public interface UserService {
     User getUser(Long userId);
     User getCurrentUser();
     void createUser(UserReq userReq);
     User getUserByEmail(String email);
-    JwtToken Login(LoginReq loginReq);
+
+    LoginRes loginOAuth(String target, String code);
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
@@ -1,19 +1,19 @@
 package ForMZ.Server.domain.user.service;
 
+import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.dto.UserReq;
 import ForMZ.Server.domain.user.entity.User;
 import ForMZ.Server.domain.user.exception.UserNotFoundException;
 import ForMZ.Server.domain.user.mapper.UserMapper;
 import ForMZ.Server.domain.user.repository.UserRepository;
-import ForMZ.Server.global.auth.jwt.dto.JwtToken;
-import ForMZ.Server.global.auth.jwt.dto.LoginReq;
-import ForMZ.Server.global.auth.jwt.tokenizer.JwtTokenProvider;
+import ForMZ.Server.global.jwt.JwtFactory;
+import ForMZ.Server.global.oauth.OAuthRequestUtil;
+import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +21,8 @@ public class UserServiceImpl implements UserService{
 
     private final UserMapper mapper;
     private final UserRepository userRepository;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final OAuthRequestUtil oAuthRequestUtil;
+    private final JwtFactory jwtFactory;
 
     /**
      * UserId를 통한 유저 조회
@@ -42,24 +42,24 @@ public class UserServiceImpl implements UserService{
         return getUser(userId);
     }
 
-    @Override
-    @Transactional
-    public JwtToken Login(LoginReq loginReq) {
-
-        final String email = loginReq.getEmail();
-        final String password = loginReq.getPassword();
-
-        // email + password 기반으로 Authentication 객체 생성
-        // 이 때, authentication 은 인증 여부를 확인하는 authenticated 값이 false
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
-
-        // 실제 검증. authenticate() 메서드를 통해 요청된 User에 대한 검증 진행
-        // authenticate 메서드가 실행될 때 CustomUserDetailsService에서 만든 loadUserByUsername 메서드 실행
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-        // 인증 정보를 기반으로 JWT 토큰 생성
-        return jwtTokenProvider.generateToken(authentication);
-    }
+//    @Override
+//    @Transactional
+//    public JwtToken Login(LoginReq loginReq) {
+//
+//        final String email = loginReq.getEmail();
+//        final String password = loginReq.getPassword();
+//
+//        // email + password 기반으로 Authentication 객체 생성
+//        // 이 때, authentication 은 인증 여부를 확인하는 authenticated 값이 false
+//        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+//
+//        // 실제 검증. authenticate() 메서드를 통해 요청된 User에 대한 검증 진행
+//        // authenticate 메서드가 실행될 때 CustomUserDetailsService에서 만든 loadUserByUsername 메서드 실행
+//        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+//
+//        // 인증 정보를 기반으로 JWT 토큰 생성
+//        return jwtTokenProvider.generateToken(authentication);
+//    }
 
     /**
      * 회원가입
@@ -75,5 +75,28 @@ public class UserServiceImpl implements UserService{
     public User getUserByEmail(String email){
         return userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+//    @Override
+//    public LoginRes Login(LoginReq loginReq) {
+//        return null;
+//    }
+
+    @Override
+    @Transactional
+    public LoginRes loginOAuth(String target, String code) {
+        OAuthUserInfo oAuthUserInfo = oAuthRequestUtil.getOAuthUserInfo(target, code);
+
+        User user = userRepository.findBySignTypeAndSocialId(oAuthUserInfo.getSocialType(), oAuthUserInfo.getSocialId())
+                .map(existUser -> {
+                    existUser.updateOAuthInfo(oAuthUserInfo);
+                    return existUser;
+                })
+                .orElse(userRepository.save(User.toEntity(oAuthUserInfo)));
+
+        // TODO : JWT Service 변경
+        String accessToken = jwtFactory.createAccessToken(user.getId());
+
+        return LoginRes.toDto(accessToken);
     }
 }

--- a/Server/src/main/java/ForMZ/Server/global/config/SecurityConfig.java
+++ b/Server/src/main/java/ForMZ/Server/global/config/SecurityConfig.java
@@ -6,17 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -35,15 +32,10 @@ public class SecurityConfig {
                 .addFilterBefore(new AuthorizationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 
         http
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/login"),
-                                new AntPathRequestMatcher("/email")
-                        ).permitAll()
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/my-page")
-                        ).hasRole("USER")
-                        .anyRequest().authenticated());
+                .authorizeHttpRequests(auth ->
+                        auth
+                                .requestMatchers("/api/**").authenticated()
+                                .anyRequest().permitAll());
 
         return http.build();
     }

--- a/Server/src/main/java/ForMZ/Server/global/oauth/dto/OAuthUserInfo.java
+++ b/Server/src/main/java/ForMZ/Server/global/oauth/dto/OAuthUserInfo.java
@@ -1,5 +1,6 @@
 package ForMZ.Server.global.oauth.dto;
 
+import ForMZ.Server.domain.user.entity.SignType;
 import ForMZ.Server.global.oauth.exception.SocialTypeNotFoundException;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,13 +12,14 @@ import java.util.Map;
 public class OAuthUserInfo {
     private String socialId;
 
-    private String socialType;
+    private SignType socialType;
 
     private String email;
 
     private String imageUrl;
 
     public static OAuthUserInfo getOAuthUserInfoBySocial(String target, Map<String, Object> attribute) {
+        target = target.toUpperCase();
         return switch (target) {
             case "google" -> toGoogleUserInfo(target, attribute);
             case "kakao" -> toKakaoUserInfo(target, attribute);
@@ -28,7 +30,7 @@ public class OAuthUserInfo {
 
     private static OAuthUserInfo toGoogleUserInfo(String social, Map<String, Object> attribute) {
         return OAuthUserInfo.builder()
-                .socialType(social.toUpperCase())
+                .socialType(SignType.valueOf(social))
                 .socialId((String) attribute.get("id"))
                 .email((String) attribute.get("email"))
                 .imageUrl((String) attribute.get("picture"))
@@ -39,7 +41,7 @@ public class OAuthUserInfo {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
         Map<String, Object> properties = (Map<String, Object>) attribute.get("properties");
         return OAuthUserInfo.builder()
-                .socialType(social.toUpperCase())
+                .socialType(SignType.valueOf(social))
                 .socialId(String.valueOf(attribute.get("id")))
                 .email((String) kakaoAccount.get("email"))
                 .imageUrl((String) properties.get("profile_image"))
@@ -49,7 +51,7 @@ public class OAuthUserInfo {
     private static OAuthUserInfo toNaverUserInfo(String social, Map<String, Object> attribute) {
         Map<String, Object> naverAccount = (Map<String, Object>) attribute.get("response");
         return OAuthUserInfo.builder()
-                .socialType(social.toUpperCase())
+                .socialType(SignType.valueOf(social))
                 .socialId((String) naverAccount.get("id"))
                 .email((String) naverAccount.get("email"))
                 .imageUrl((String) naverAccount.get("profile_image"))

--- a/Server/src/main/java/ForMZ/Server/global/oauth/dto/OAuthUserInfo.java
+++ b/Server/src/main/java/ForMZ/Server/global/oauth/dto/OAuthUserInfo.java
@@ -15,6 +15,8 @@ public class OAuthUserInfo {
 
     private String email;
 
+    private String imageUrl;
+
     public static OAuthUserInfo getOAuthUserInfoBySocial(String target, Map<String, Object> attribute) {
         return switch (target) {
             case "google" -> toGoogleUserInfo(target, attribute);
@@ -29,15 +31,18 @@ public class OAuthUserInfo {
                 .socialType(social.toUpperCase())
                 .socialId((String) attribute.get("id"))
                 .email((String) attribute.get("email"))
+                .imageUrl((String) attribute.get("picture"))
                 .build();
     }
 
     private static OAuthUserInfo toKakaoUserInfo(String social, Map<String, Object> attribute) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        Map<String, Object> properties = (Map<String, Object>) attribute.get("properties");
         return OAuthUserInfo.builder()
                 .socialType(social.toUpperCase())
-                .socialId((String) attribute.get("id"))
+                .socialId(String.valueOf(attribute.get("id")))
                 .email((String) kakaoAccount.get("email"))
+                .imageUrl((String) properties.get("profile_image"))
                 .build();
     }
 
@@ -47,6 +52,7 @@ public class OAuthUserInfo {
                 .socialType(social.toUpperCase())
                 .socialId((String) naverAccount.get("id"))
                 .email((String) naverAccount.get("email"))
+                .imageUrl((String) naverAccount.get("profile_image"))
                 .build();
     }
 }

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
@@ -1,0 +1,87 @@
+package ForMZ.Server.domain.user;
+
+import ForMZ.Server.domain.user.controller.UserController;
+import ForMZ.Server.domain.user.dto.LoginRes;
+import ForMZ.Server.domain.user.service.MailSenderService;
+import ForMZ.Server.domain.user.service.UserService;
+import ForMZ.Server.global.config.TestConfig;
+import ForMZ.Server.global.oauth.exception.AuthorizationCodeErrorException;
+import ForMZ.Server.global.oauth.exception.SocialTypeNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import(TestConfig.class)
+public class UserControllerTest {
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    MailSenderService mailSenderService;
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("OAuth 로그인 / Access Token 정상 발행")
+    void isSuccessLoginToOAuth() throws Exception {
+        // given
+        String social = "social";
+        String code = "code";
+        LoginRes loginRes = LoginRes.toDto("토큰");
+        doReturn(loginRes).when(userService).loginOAuth(social, code);
+
+        // when
+        ResultActions perform = mvc.perform(post("/login").param("target", social).param("code", code));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value(loginRes.getAccessToken()));
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인 / Authorization Code Error Exception")
+    void isAuthorizationCodeError() throws Exception {
+        // given
+        String authorizationCode = "잘못된 Authorization Code";
+        AuthorizationCodeErrorException exception = new AuthorizationCodeErrorException();
+        doThrow(exception).when(userService).loginOAuth("social", authorizationCode);
+
+        // when
+        ResultActions perform = mvc.perform(post("/login").param("target", "social").param("code", authorizationCode));
+
+        // then
+        perform.andExpect(status().is(exception.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(exception.getMessage()));
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인 / Social Type Not Found Exception")
+    void isNotFoundSocialType() throws Exception {
+        // given
+        String socialType = "지원하지 않는 소셜 로그인 타입";
+        SocialTypeNotFoundException exception = new SocialTypeNotFoundException();
+        doThrow(exception).when(userService).loginOAuth(anyString(), anyString());
+
+        // when
+        ResultActions perform = mvc.perform(post("/login").param("target", socialType).param("code", "code"));
+
+        // then
+        perform.andExpect(status().is(exception.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(exception.getMessage()));
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserRepositoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserRepositoryTest.java
@@ -1,0 +1,88 @@
+package ForMZ.Server.domain.user;
+
+import ForMZ.Server.domain.user.entity.SignType;
+import ForMZ.Server.domain.user.entity.User;
+import ForMZ.Server.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class UserRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("Find By SignType, SocialId 정상")
+    void checkFindBySignTypeAndSocialId() {
+        // given
+        SignType signType = SignType.GOOGLE;
+        String socialId = "test";
+        userRepository.save(makeUser(signType, socialId));
+        
+        // when
+        Optional<User> optional = userRepository.findBySignTypeAndSocialId(signType, socialId);
+
+        // then
+        assertThat(optional).isNotEmpty();
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("SignType, SocialId Index 조회 성능 테스트")
+    void performanceTestByIndex() {
+        // given
+        SignType signType = SignType.GOOGLE;
+        String socialId = "test";
+        saveUserEntityByCount(100000);
+        userRepository.save(makeUser(signType, socialId));
+        em.clear();
+
+        // when
+        Date now = new Date();
+        userRepository.findBySignTypeAndSocialId(SignType.GOOGLE, "test");
+        System.out.println("경과 시간 : " + (new Date().getTime() - now.getTime()));
+
+        em.clear();
+    }
+
+    private void saveUserEntityByCount(int count) {
+        List<User> userList = new ArrayList<>();
+
+        while (count -- > 0) {
+            userList.add(makeUser(SignType.values()[count % SignType.values().length], UUID.randomUUID().toString()));
+        }
+
+        userRepository.saveAll(userList);
+    }
+
+    private User makeUser(SignType signType, String socialId) {
+        return User.builder()
+                .email("test@test.com")
+                .nickName("test")
+                .signType(signType)
+                .socialId(socialId)
+                .build();
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
@@ -1,0 +1,78 @@
+package ForMZ.Server.domain.user;
+
+import ForMZ.Server.domain.user.dto.LoginRes;
+import ForMZ.Server.domain.user.entity.User;
+import ForMZ.Server.domain.user.repository.UserRepository;
+import ForMZ.Server.domain.user.service.UserServiceImpl;
+import ForMZ.Server.global.jwt.JwtFactory;
+import ForMZ.Server.global.oauth.OAuthRequestUtil;
+import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceImplTest {
+
+    @InjectMocks
+    UserServiceImpl userService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    OAuthRequestUtil oAuthRequestUtil;
+
+    @Mock
+    JwtFactory jwtFactory;
+
+    @Test
+    @DisplayName("OAuth 첫 로그인, Access Token 발급")
+    void loginOAuth_issueAccessToken() {
+        // given
+        String accessToken = "토큰";
+        User user = User.builder().id(1L).build();
+        OAuthUserInfo oAuthUserInfo = OAuthUserInfo.builder().build();
+
+        doReturn(oAuthUserInfo).when(oAuthRequestUtil).getOAuthUserInfo(anyString(), anyString());
+        doReturn(Optional.empty()).when(userRepository).findBySignTypeAndSocialId(oAuthUserInfo.getSocialType(), oAuthUserInfo.getSocialId());
+        doReturn(user).when(userRepository).save(any());
+        doReturn(accessToken).when(jwtFactory).createAccessToken(user.getId());
+
+        // when
+        LoginRes loginRes = userService.loginOAuth(anyString(), anyString());
+
+        // then
+        assertThat(loginRes.getAccessToken()).isEqualTo(accessToken);
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인, User 정보 변경, Access Token 발급")
+    void loginOAuthUpdateEmail_issueAccessToken() {
+        // given
+        String accessToken = "토큰";
+        String updateEmail = "변경 이메일";
+        User user = User.builder().id(1L).email("기존 이메일").build();
+        OAuthUserInfo oAuthUserInfo = OAuthUserInfo.builder().email(updateEmail).build();
+
+        doReturn(oAuthUserInfo).when(oAuthRequestUtil).getOAuthUserInfo(anyString(), anyString());
+        doReturn(Optional.of(user)).when(userRepository).findBySignTypeAndSocialId(oAuthUserInfo.getSocialType(), oAuthUserInfo.getSocialId());
+        doReturn(accessToken).when(jwtFactory).createAccessToken(user.getId());
+
+        // when
+        LoginRes loginRes = userService.loginOAuth(anyString(), anyString());
+
+        // then
+        assertThat(user.getEmail()).isEqualTo(updateEmail);
+        assertThat(loginRes.getAccessToken()).isEqualTo(accessToken);
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/global/config/TestConfig.java
+++ b/Server/src/test/java/ForMZ/Server/global/config/TestConfig.java
@@ -1,0 +1,23 @@
+package ForMZ.Server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class TestConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Key Changes 🔑
<!-- 주요 구현 사항 -->
- OAuth Login Controller, Service 구현


## To Reviewers 🙌🏻
<!-- 리뷰어에게 전달할 말 -->
- `JwtFactory`의 `createAccessToken()` 대신 Service Layer 추가 및 내부에서 Token 저장 및 발급


## PR Checklist ✔️
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요 -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

## PR 타입 👏🏻
<!--- 하나 이상의 PR 타입을 선택해주세요 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

