### PR TITLE
Feat : Refresh Token Cookie 작업 및 로그아웃 API 구현

### DIFF
--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.h2database:h2'
+	testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	//MySQL
 	implementation 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtFactory.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtFactory.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt;
+package ForMZ.Server.domain.jwt;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtProperty.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtProperty.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt;
+package ForMZ.Server.domain.jwt;
 
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtProvider.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtProvider.java
@@ -1,7 +1,7 @@
-package ForMZ.Server.global.jwt;
+package ForMZ.Server.domain.jwt;
 
-import ForMZ.Server.global.jwt.exception.JwtExpirationException;
-import ForMZ.Server.global.jwt.exception.JwtModulationException;
+import ForMZ.Server.domain.jwt.exception.JwtExpirationException;
+import ForMZ.Server.domain.jwt.exception.JwtModulationException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtRepository.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtRepository.java
@@ -2,5 +2,8 @@ package ForMZ.Server.domain.jwt;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.Optional;
+
 public interface JwtRepository extends CrudRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByUserId(long userId);
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtRepository.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtRepository.java
@@ -1,0 +1,6 @@
+package ForMZ.Server.domain.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface JwtRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.domain.jwt;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,11 +9,13 @@ import org.springframework.stereotype.Service;
 public class JwtService {
 
     private final JwtFactory jwtFactory;
+    private final JwtProperty jwtProperty;
     private final JwtRepository jwtRepository;
 
     @Transactional
     public JwtToken createJwtToken(long userId) {
-        RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(jwtFactory.createRefreshToken(), userId));
+        RefreshToken refreshToken = jwtRepository.findByUserId(userId)
+                .orElse(jwtRepository.save(RefreshToken.toEntity(jwtFactory.createRefreshToken(), userId, jwtProperty.getRefreshExpiration())));
         return new JwtToken(jwtFactory.createAccessToken(userId), refreshToken.getValue());
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
@@ -14,6 +14,6 @@ public class JwtService {
     @Transactional
     public JwtToken createJwtToken(long userId) {
         RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(jwtFactory.createRefreshToken(), userId));
-        return new JwtToken(jwtFactory.createAccessToken(userId), refreshToken.getRefreshToken());
+        return new JwtToken(jwtFactory.createAccessToken(userId), refreshToken.getValue());
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtService.java
@@ -1,0 +1,19 @@
+package ForMZ.Server.domain.jwt;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtFactory jwtFactory;
+    private final JwtRepository jwtRepository;
+
+    @Transactional
+    public JwtToken createJwtToken(long userId) {
+        RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(jwtFactory.createRefreshToken(), userId));
+        return new JwtToken(jwtFactory.createAccessToken(userId), refreshToken.getRefreshToken());
+    }
+}

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/JwtToken.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/JwtToken.java
@@ -1,0 +1,6 @@
+package ForMZ.Server.domain.jwt;
+
+public record JwtToken (
+        String accessToken,
+        String refreshToken
+) {}

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
@@ -1,0 +1,23 @@
+package ForMZ.Server.domain.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+
+    private long userId;
+
+    public static RefreshToken toEntity(String refreshToken, long userId) {
+        return RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .userId(userId)
+                .build();
+    }
+}

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
@@ -4,20 +4,25 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
 @Getter
 @Builder
-@RedisHash(value = "refreshToken", timeToLive = 1209600)
+@RedisHash("refreshToken")
 public class RefreshToken {
     @Id
-    private String refreshToken;
+    private String value;
 
     private long userId;
 
+    @TimeToLive
+    private long ttl;
+
     public static RefreshToken toEntity(String refreshToken, long userId) {
         return RefreshToken.builder()
-                .refreshToken(refreshToken)
+                .value(refreshToken)
                 .userId(userId)
+                .ttl(Long.parseLong(System.getProperty("jwt.refresh.expiration")) / 1000)
                 .build();
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
@@ -2,6 +2,7 @@ package ForMZ.Server.domain.jwt;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -19,10 +20,11 @@ public class RefreshToken {
     private long ttl;
 
     public static RefreshToken toEntity(String refreshToken, long userId) {
+        String ttl = new AnnotationConfigApplicationContext().getEnvironment().getProperty("jwt.refresh.expiration");
         return RefreshToken.builder()
                 .value(refreshToken)
                 .userId(userId)
-                .ttl(Long.parseLong(System.getProperty("jwt.refresh.expiration")) / 1000)
+                .ttl(Long.parseLong(ttl) / 1000)
                 .build();
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/RefreshToken.java
@@ -2,10 +2,10 @@ package ForMZ.Server.domain.jwt;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @Builder
@@ -14,17 +14,17 @@ public class RefreshToken {
     @Id
     private String value;
 
+    @Indexed
     private long userId;
 
     @TimeToLive
     private long ttl;
 
-    public static RefreshToken toEntity(String refreshToken, long userId) {
-        String ttl = new AnnotationConfigApplicationContext().getEnvironment().getProperty("jwt.refresh.expiration");
+    public static RefreshToken toEntity(String refreshToken, long userId, long milliSecond) {
         return RefreshToken.builder()
                 .value(refreshToken)
                 .userId(userId)
-                .ttl(Long.parseLong(ttl) / 1000)
+                .ttl(milliSecond / 1000)
                 .build();
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/exception/JwtExpirationException.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/exception/JwtExpirationException.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt.exception;
+package ForMZ.Server.domain.jwt.exception;
 
 import ForMZ.Server.global.exception.ApplicationException;
 import org.springframework.http.HttpStatus;

--- a/Server/src/main/java/ForMZ/Server/domain/jwt/exception/JwtModulationException.java
+++ b/Server/src/main/java/ForMZ/Server/domain/jwt/exception/JwtModulationException.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt.exception;
+package ForMZ.Server.domain.jwt.exception;
 
 import ForMZ.Server.global.exception.ApplicationException;
 import org.springframework.http.HttpStatus;

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -8,6 +8,8 @@ import ForMZ.Server.domain.user.service.MailSenderService;
 import ForMZ.Server.domain.user.service.UserService;
 import ForMZ.Server.global.common.ResponseDto;
 import ForMZ.Server.domain.user.dto.UserReq;
+import ForMZ.Server.global.cookie.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import static ForMZ.Server.domain.user.constant.UserConstant.AuthResponseMessage
 @RequiredArgsConstructor
 public class UserController {
 
+    private final CookieUtil cookieUtil;
     private final UserService userService;
     private final MailSenderService mailSenderService;
 
@@ -53,8 +56,9 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> loginOAuth(@RequestParam("target") String target, @RequestParam("code") String code) {
+    public ResponseEntity<?> loginOAuth(@RequestParam("target") String target, @RequestParam("code") String code, HttpServletResponse response) {
         JwtToken jwtToken = userService.loginOAuth(target, code);
+        cookieUtil.setRefreshTokenInCookie(response, jwtToken.refreshToken());
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), new LoginRes(jwtToken.accessToken())));
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -61,4 +61,10 @@ public class UserController {
         cookieUtil.setRefreshTokenInCookie(response, jwtToken.refreshToken());
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), new LoginRes(jwtToken.accessToken())));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        cookieUtil.deleteRefreshTokenInCookie(response);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), null));
+    }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package ForMZ.Server.domain.user.controller;
 
 import ForMZ.Server.domain.jwt.JwtToken;
+import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.dto.MailReq;
 import ForMZ.Server.domain.user.dto.MailRes;
 import ForMZ.Server.domain.user.service.MailSenderService;
@@ -54,6 +55,6 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<?> loginOAuth(@RequestParam("target") String target, @RequestParam("code") String code) {
         JwtToken jwtToken = userService.loginOAuth(target, code);
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), jwtToken));
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), new LoginRes(jwtToken.accessToken())));
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.domain.user.controller;
 
-import ForMZ.Server.domain.user.dto.LoginRes;
+import ForMZ.Server.domain.jwt.JwtToken;
 import ForMZ.Server.domain.user.dto.MailReq;
 import ForMZ.Server.domain.user.dto.MailRes;
 import ForMZ.Server.domain.user.service.MailSenderService;
@@ -53,7 +53,7 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<?> loginOAuth(@RequestParam("target") String target, @RequestParam("code") String code) {
-        LoginRes loginRes = userService.loginOAuth(target, code);
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), loginRes));
+        JwtToken jwtToken = userService.loginOAuth(target, code);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.create(HttpStatus.OK.value(), LOGIN_USER_SUCCESS.getMessage(), jwtToken));
     }
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/dto/LoginRes.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/dto/LoginRes.java
@@ -1,15 +1,5 @@
 package ForMZ.Server.domain.user.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder(access = AccessLevel.PRIVATE)
-public class LoginRes {
-    private String accessToken;
-
-    public static LoginRes toDto(String accessToken) {
-        return LoginRes.builder().accessToken(accessToken).build();
-    }
-}
+public record LoginRes(
+        String accessToken
+) {}

--- a/Server/src/main/java/ForMZ/Server/domain/user/service/UserService.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.domain.user.service;
 
-import ForMZ.Server.domain.user.dto.LoginRes;
+import ForMZ.Server.domain.jwt.JwtToken;
 import ForMZ.Server.domain.user.dto.UserReq;
 import ForMZ.Server.domain.user.entity.User;
 
@@ -10,5 +10,5 @@ public interface UserService {
     void createUser(UserReq userReq);
     User getUserByEmail(String email);
 
-    LoginRes loginOAuth(String target, String code);
+    JwtToken loginOAuth(String target, String code);
 }

--- a/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
@@ -6,7 +6,7 @@ import ForMZ.Server.domain.user.entity.User;
 import ForMZ.Server.domain.user.exception.UserNotFoundException;
 import ForMZ.Server.domain.user.mapper.UserMapper;
 import ForMZ.Server.domain.user.repository.UserRepository;
-import ForMZ.Server.global.jwt.JwtFactory;
+import ForMZ.Server.domain.jwt.JwtFactory;
 import ForMZ.Server.global.oauth.OAuthRequestUtil;
 import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
 import jakarta.transaction.Transactional;

--- a/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
+++ b/Server/src/main/java/ForMZ/Server/domain/user/service/UserServiceImpl.java
@@ -9,7 +9,7 @@ import ForMZ.Server.domain.user.mapper.UserMapper;
 import ForMZ.Server.domain.user.repository.UserRepository;
 import ForMZ.Server.global.oauth.OAuthRequestUtil;
 import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/Server/src/main/java/ForMZ/Server/global/config/RedisConfig.java
+++ b/Server/src/main/java/ForMZ/Server/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package ForMZ.Server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/Server/src/main/java/ForMZ/Server/global/config/RedisConfig.java
+++ b/Server/src/main/java/ForMZ/Server/global/config/RedisConfig.java
@@ -4,11 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
-@EnableRedisRepositories
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 public class RedisConfig {
     @Value("${redis.host}")
     private String host;
@@ -16,8 +18,13 @@ public class RedisConfig {
     @Value("${redis.port}")
     private int port;
 
+    @Value("${redis.password}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+        redisConfig.setPassword(password);
+        return new LettuceConnectionFactory(redisConfig);
     }
 }

--- a/Server/src/main/java/ForMZ/Server/global/config/SecurityConfig.java
+++ b/Server/src/main/java/ForMZ/Server/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.global.config;
 
-import ForMZ.Server.global.jwt.JwtProvider;
+import ForMZ.Server.domain.jwt.JwtProvider;
 import ForMZ.Server.global.security.AuthorizationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/Server/src/main/java/ForMZ/Server/global/cookie/CookieUtil.java
+++ b/Server/src/main/java/ForMZ/Server/global/cookie/CookieUtil.java
@@ -18,6 +18,10 @@ public class CookieUtil {
         setCookie(response, maxAge / 1000, refreshToken);
     }
 
+    public void deleteRefreshTokenInCookie(HttpServletResponse response) {
+        setCookie(response, 0, null);
+    }
+
     private void setCookie(HttpServletResponse response, long maxAge, String value) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_HEADER, value)
                 .httpOnly(true)

--- a/Server/src/main/java/ForMZ/Server/global/cookie/CookieUtil.java
+++ b/Server/src/main/java/ForMZ/Server/global/cookie/CookieUtil.java
@@ -1,0 +1,32 @@
+package ForMZ.Server.global.cookie;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    private static final String SET_COOKIE = "Set-Cookie";
+
+    private static final String REFRESH_HEADER = "Refresh";
+
+    @Value("${jwt.refresh.expiration}")
+    private long maxAge;
+
+    public void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
+        setCookie(response, maxAge / 1000, refreshToken);
+    }
+
+    private void setCookie(HttpServletResponse response, long maxAge, String value) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_HEADER, value)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("NONE")
+                .maxAge(maxAge)
+                .path("/refresh")
+                .build();
+
+        response.addHeader(SET_COOKIE, cookie.toString());
+    }
+}

--- a/Server/src/main/java/ForMZ/Server/global/security/AuthorizationFilter.java
+++ b/Server/src/main/java/ForMZ/Server/global/security/AuthorizationFilter.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.global.security;
 
-import ForMZ.Server.global.jwt.JwtProvider;
+import ForMZ.Server.domain.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtFactoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtFactoryTest.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt;
+package ForMZ.Server.domain.jwt;
 
 import ForMZ.Server.domain.jwt.JwtFactory;
 import ForMZ.Server.domain.jwt.JwtProperty;

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtProviderTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtProviderTest.java
@@ -1,4 +1,4 @@
-package ForMZ.Server.global.jwt;
+package ForMZ.Server.domain.jwt;
 
 import ForMZ.Server.domain.jwt.JwtFactory;
 import ForMZ.Server.domain.jwt.JwtProperty;

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
@@ -89,7 +89,7 @@ public class JwtRepositoryTest {
     @DisplayName("Secondary Index 탐색 시간 비교")
     void findSecondaryIndexTimeCheck() {
         // given
-        int last = 50_000;
+        int last = 10;
         for (int i = 0; i < last; i++) {
             jwtRepository.save(RefreshToken.toEntity("refresh" + i, i, 100000));
         }

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
@@ -49,7 +49,7 @@ public class JwtRepositoryTest {
         // then
         assertThat(optional).isNotEmpty();
         RefreshToken refreshToken = optional.get();
-        assertThat(refreshToken.getRefreshToken()).isEqualTo(token);
+        assertThat(refreshToken.getValue()).isEqualTo(token);
         assertThat(refreshToken.getUserId()).isEqualTo(userId);
     }
 

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
@@ -1,0 +1,71 @@
+package ForMZ.Server.domain.jwt;
+
+import ForMZ.Server.global.config.RedisConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(RedisConfig.class)
+@DataRedisTest
+@Testcontainers
+public class JwtRepositoryTest {
+
+    @Autowired
+    JwtRepository jwtRepository;
+
+    @Container
+    private static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+                    .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("redis.host", redis::getHost);
+        registry.add("redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Test
+    @DisplayName("Redis 저장 및 조회 - 정상")
+    void saveRedisTest() {
+        // given
+        String token = "리프레시 토큰";
+        long userId = 1L;
+        jwtRepository.save(RefreshToken.toEntity(token, userId));
+
+        // when
+        Optional<RefreshToken> optional = jwtRepository.findById(token);
+
+        // then
+        assertThat(optional).isNotEmpty();
+        RefreshToken refreshToken = optional.get();
+        assertThat(refreshToken.getRefreshToken()).isEqualTo(token);
+        assertThat(refreshToken.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("Redis 삭제 - 정상")
+    void deleteRedisTest() {
+        // given
+        String token = "리프레시 토큰";
+        long userId = 1L;
+        RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(token, userId));
+
+        // when
+        jwtRepository.delete(refreshToken);
+        Optional<RefreshToken> optional = jwtRepository.findById(token);
+
+        // then
+        assertThat(optional).isEmpty();
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtRepositoryTest.java
@@ -41,7 +41,7 @@ public class JwtRepositoryTest {
         // given
         String token = "리프레시 토큰";
         long userId = 1L;
-        jwtRepository.save(RefreshToken.toEntity(token, userId));
+        jwtRepository.save(RefreshToken.toEntity(token, userId, 5000));
 
         // when
         Optional<RefreshToken> optional = jwtRepository.findById(token);
@@ -59,7 +59,7 @@ public class JwtRepositoryTest {
         // given
         String token = "리프레시 토큰";
         long userId = 1L;
-        RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(token, userId));
+        RefreshToken refreshToken = jwtRepository.save(RefreshToken.toEntity(token, userId, 5000));
 
         // when
         jwtRepository.delete(refreshToken);
@@ -67,5 +67,38 @@ public class JwtRepositoryTest {
 
         // then
         assertThat(optional).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Redis TTL 삭제 - 정상")
+    void ttlTest() throws InterruptedException {
+        // given
+        String token = "리프레시 토큰";
+        long userId = 1L;
+        jwtRepository.save(RefreshToken.toEntity(token, userId, 1000));
+
+        // when
+        Thread.sleep(1000);
+        Optional<RefreshToken> optional = jwtRepository.findById(token);
+
+        // then
+        assertThat(optional).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Secondary Index 탐색 시간 비교")
+    void findSecondaryIndexTimeCheck() {
+        // given
+        int last = 50_000;
+        for (int i = 0; i < last; i++) {
+            jwtRepository.save(RefreshToken.toEntity("refresh" + i, i, 100000));
+        }
+
+        // when, then
+        long start = System.nanoTime();
+        Optional<RefreshToken> optional = jwtRepository.findByUserId(last);
+        System.out.println("경과 시간 : " + ((System.nanoTime() - start) / 1_000_000) + "ms");
+        // Secondary Index (X) -> 1만건 : 27ms, 5만건 : 155ms
+        // Secondary Index (O) -> 1만건 : 24ms, 5만건 : 44ms
     }
 }

--- a/Server/src/test/java/ForMZ/Server/domain/jwt/JwtServiceTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/jwt/JwtServiceTest.java
@@ -1,0 +1,52 @@
+package ForMZ.Server.domain.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtServiceTest {
+
+    @InjectMocks
+    JwtService jwtService;
+
+    @Mock
+    JwtFactory jwtFactory;
+
+    @Mock
+    JwtProperty jwtProperty;
+
+    @Mock
+    JwtRepository jwtRepository;
+
+    @Test
+    @DisplayName("새로운 Refresh Token 발급")
+    void giveNewRefreshToken() {
+        // given
+        String accessToken = "엑세스 토큰";
+        String refreshToken = "리프레시 토큰";
+
+        doReturn(refreshToken).when(jwtFactory).createRefreshToken();
+        doReturn(accessToken).when(jwtFactory).createAccessToken(anyLong());
+        doReturn(1L).when(jwtProperty).getRefreshExpiration();
+        doReturn(Optional.empty()).when(jwtRepository).findByUserId(anyLong());
+        doReturn(RefreshToken.builder().value(refreshToken).build()).when(jwtRepository).save(any());
+
+        // when
+        JwtToken jwtToken = jwtService.createJwtToken(anyLong());
+
+        // then
+        assertThat(jwtToken.accessToken()).isEqualTo(accessToken);
+        assertThat(jwtToken.refreshToken()).isEqualTo(refreshToken);
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
@@ -1,10 +1,11 @@
 package ForMZ.Server.domain.user;
 
+import ForMZ.Server.domain.jwt.JwtToken;
 import ForMZ.Server.domain.user.controller.UserController;
-import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.service.MailSenderService;
 import ForMZ.Server.domain.user.service.UserService;
 import ForMZ.Server.global.config.TestConfig;
+import ForMZ.Server.global.cookie.CookieUtil;
 import ForMZ.Server.global.oauth.exception.AuthorizationCodeErrorException;
 import ForMZ.Server.global.oauth.exception.SocialTypeNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ public class UserControllerTest {
     @MockBean
     MailSenderService mailSenderService;
 
+    @MockBean
+    CookieUtil cookieUtil;
+
     @Autowired
     MockMvc mvc;
 
@@ -42,15 +46,15 @@ public class UserControllerTest {
         // given
         String social = "social";
         String code = "code";
-        LoginRes loginRes = new LoginRes("토큰");
-        doReturn(loginRes).when(userService).loginOAuth(social, code);
+        JwtToken jwtToken = new JwtToken("엑세스 토큰", "리프레시 토큰");
+        doReturn(jwtToken).when(userService).loginOAuth(social, code);
 
         // when
         ResultActions perform = mvc.perform(post("/login").param("target", social).param("code", code));
 
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.accessToken").value(loginRes.accessToken()));
+                .andExpect(jsonPath("$.data.accessToken").value(jwtToken.accessToken()));
     }
 
     @Test

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserControllerTest.java
@@ -42,7 +42,7 @@ public class UserControllerTest {
         // given
         String social = "social";
         String code = "code";
-        LoginRes loginRes = LoginRes.toDto("토큰");
+        LoginRes loginRes = new LoginRes("토큰");
         doReturn(loginRes).when(userService).loginOAuth(social, code);
 
         // when
@@ -50,7 +50,7 @@ public class UserControllerTest {
 
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.accessToken").value(loginRes.getAccessToken()));
+                .andExpect(jsonPath("$.data.accessToken").value(loginRes.accessToken()));
     }
 
     @Test

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
@@ -4,7 +4,7 @@ import ForMZ.Server.domain.user.dto.LoginRes;
 import ForMZ.Server.domain.user.entity.User;
 import ForMZ.Server.domain.user.repository.UserRepository;
 import ForMZ.Server.domain.user.service.UserServiceImpl;
-import ForMZ.Server.global.jwt.JwtFactory;
+import ForMZ.Server.domain.jwt.JwtFactory;
 import ForMZ.Server.global.oauth.OAuthRequestUtil;
 import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
 import org.junit.jupiter.api.DisplayName;

--- a/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
+++ b/Server/src/test/java/ForMZ/Server/domain/user/UserServiceImplTest.java
@@ -1,10 +1,10 @@
 package ForMZ.Server.domain.user;
 
-import ForMZ.Server.domain.user.dto.LoginRes;
+import ForMZ.Server.domain.jwt.JwtService;
+import ForMZ.Server.domain.jwt.JwtToken;
 import ForMZ.Server.domain.user.entity.User;
 import ForMZ.Server.domain.user.repository.UserRepository;
 import ForMZ.Server.domain.user.service.UserServiceImpl;
-import ForMZ.Server.domain.jwt.JwtFactory;
 import ForMZ.Server.global.oauth.OAuthRequestUtil;
 import ForMZ.Server.global.oauth.dto.OAuthUserInfo;
 import org.junit.jupiter.api.DisplayName;
@@ -33,46 +33,50 @@ public class UserServiceImplTest {
     OAuthRequestUtil oAuthRequestUtil;
 
     @Mock
-    JwtFactory jwtFactory;
+    JwtService jwtService;
 
     @Test
     @DisplayName("OAuth 첫 로그인, Access Token 발급")
     void loginOAuth_issueAccessToken() {
         // given
-        String accessToken = "토큰";
+        String accessToken = "엑세스 토큰";
+        String refreshToken = "리프레시 토큰";
         User user = User.builder().id(1L).build();
         OAuthUserInfo oAuthUserInfo = OAuthUserInfo.builder().build();
 
         doReturn(oAuthUserInfo).when(oAuthRequestUtil).getOAuthUserInfo(anyString(), anyString());
         doReturn(Optional.empty()).when(userRepository).findBySignTypeAndSocialId(oAuthUserInfo.getSocialType(), oAuthUserInfo.getSocialId());
         doReturn(user).when(userRepository).save(any());
-        doReturn(accessToken).when(jwtFactory).createAccessToken(user.getId());
+        doReturn(new JwtToken(accessToken, refreshToken)).when(jwtService).createJwtToken(user.getId());
 
         // when
-        LoginRes loginRes = userService.loginOAuth(anyString(), anyString());
+        JwtToken jwtToken = userService.loginOAuth(anyString(), anyString());
 
         // then
-        assertThat(loginRes.getAccessToken()).isEqualTo(accessToken);
+        assertThat(jwtToken.accessToken()).isEqualTo(accessToken);
+        assertThat(jwtToken.refreshToken()).isEqualTo(refreshToken);
     }
 
     @Test
     @DisplayName("OAuth 로그인, User 정보 변경, Access Token 발급")
     void loginOAuthUpdateEmail_issueAccessToken() {
         // given
-        String accessToken = "토큰";
+        String accessToken = "엑세스 토큰";
+        String refreshToken = "리프레시 토큰";
         String updateEmail = "변경 이메일";
         User user = User.builder().id(1L).email("기존 이메일").build();
         OAuthUserInfo oAuthUserInfo = OAuthUserInfo.builder().email(updateEmail).build();
 
         doReturn(oAuthUserInfo).when(oAuthRequestUtil).getOAuthUserInfo(anyString(), anyString());
         doReturn(Optional.of(user)).when(userRepository).findBySignTypeAndSocialId(oAuthUserInfo.getSocialType(), oAuthUserInfo.getSocialId());
-        doReturn(accessToken).when(jwtFactory).createAccessToken(user.getId());
+        doReturn(new JwtToken(accessToken, refreshToken)).when(jwtService).createJwtToken(user.getId());
 
         // when
-        LoginRes loginRes = userService.loginOAuth(anyString(), anyString());
+        JwtToken jwtToken = userService.loginOAuth(anyString(), anyString());
 
         // then
         assertThat(user.getEmail()).isEqualTo(updateEmail);
-        assertThat(loginRes.getAccessToken()).isEqualTo(accessToken);
+        assertThat(jwtToken.accessToken()).isEqualTo(accessToken);
+        assertThat(jwtToken.refreshToken()).isEqualTo(refreshToken);
     }
 }

--- a/Server/src/test/java/ForMZ/Server/global/config/TestConfig.java
+++ b/Server/src/test/java/ForMZ/Server/global/config/TestConfig.java
@@ -1,13 +1,13 @@
 package ForMZ.Server.global.config;
 
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
+@TestConfiguration
 public class TestConfig {
 
     @Bean

--- a/Server/src/test/java/ForMZ/Server/global/cookie/CookieUtilTest.java
+++ b/Server/src/test/java/ForMZ/Server/global/cookie/CookieUtilTest.java
@@ -1,0 +1,37 @@
+package ForMZ.Server.global.cookie;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class CookieUtilTest {
+
+    @InjectMocks
+    CookieUtil cookieUtil;
+
+    @Test
+    @DisplayName("Cookie 설정 - 정상")
+    void setCookieTest() {
+        // given
+        HttpServletResponse response = new MockHttpServletResponse();
+        String refreshToken = "refresh";
+
+        // when
+        cookieUtil.setRefreshTokenInCookie(response, refreshToken);
+
+        // then
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        assertThat(setCookie.indexOf("HttpOnly")).isNotEqualTo(-1);
+        assertThat(setCookie.indexOf("Secure")).isNotEqualTo(-1);
+        assertThat(setCookie.indexOf("SameSite=NONE")).isNotEqualTo(-1);
+        assertThat(setCookie.indexOf("Path=/refresh")).isNotEqualTo(-1);
+    }
+}

--- a/Server/src/test/java/ForMZ/Server/global/cookie/CookieUtilTest.java
+++ b/Server/src/test/java/ForMZ/Server/global/cookie/CookieUtilTest.java
@@ -34,4 +34,19 @@ class CookieUtilTest {
         assertThat(setCookie.indexOf("SameSite=NONE")).isNotEqualTo(-1);
         assertThat(setCookie.indexOf("Path=/refresh")).isNotEqualTo(-1);
     }
+
+    @Test
+    @DisplayName("Cookie 삭제 - 정상")
+    void deleteCookieTest() {
+        // given
+        HttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        cookieUtil.deleteRefreshTokenInCookie(response);
+
+        // then
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        assertThat(setCookie.indexOf("Max-Age=0")).isNotEqualTo(-1);
+    }
 }

--- a/Server/src/test/java/ForMZ/Server/global/jwt/JwtFactoryTest.java
+++ b/Server/src/test/java/ForMZ/Server/global/jwt/JwtFactoryTest.java
@@ -1,5 +1,7 @@
 package ForMZ.Server.global.jwt;
 
+import ForMZ.Server.domain.jwt.JwtFactory;
+import ForMZ.Server.domain.jwt.JwtProperty;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/Server/src/test/java/ForMZ/Server/global/jwt/JwtProviderTest.java
+++ b/Server/src/test/java/ForMZ/Server/global/jwt/JwtProviderTest.java
@@ -1,7 +1,10 @@
 package ForMZ.Server.global.jwt;
 
-import ForMZ.Server.global.jwt.exception.JwtExpirationException;
-import ForMZ.Server.global.jwt.exception.JwtModulationException;
+import ForMZ.Server.domain.jwt.JwtFactory;
+import ForMZ.Server.domain.jwt.JwtProperty;
+import ForMZ.Server.domain.jwt.JwtProvider;
+import ForMZ.Server.domain.jwt.exception.JwtExpirationException;
+import ForMZ.Server.domain.jwt.exception.JwtModulationException;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/Server/src/test/java/ForMZ/Server/global/security/AuthorizationFilterTest.java
+++ b/Server/src/test/java/ForMZ/Server/global/security/AuthorizationFilterTest.java
@@ -1,6 +1,6 @@
 package ForMZ.Server.global.security;
 
-import ForMZ.Server.global.jwt.JwtProvider;
+import ForMZ.Server.domain.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;


### PR DESCRIPTION
## Key Changes 🔑
<!-- 주요 구현 사항 -->
- Refresh Token HttpOnly Cookie 적용
- Redis에서 User Id 기반으로 Find 후 존재할 경우 기존의 Refresh Token 발급
- Logout API 구현

## To Reviewers 🙌🏻
<!-- 리뷰어에게 전달할 말 -->
- HttpOnly Cookie로 Refresh Token 전달
  - XSS 공격에 의해 Refresh Token 탈취를 방지하고자 도입
- 중복 로그인 시, Refresh Token 동일 값 발급
  - PC 로그인 후 Mobile 로그인 시, 서로 다른 Refresh Token 발급 될 경우 기존 PC의 Refresh Token 무효화 방지
  - 설정한 TTL 시간 동안, Redis에선 삭제되지 않고 Refresh Token 계속 유지 -> 메모리 손해 발생
    - [ ] Refresh Token 발급 횟수를 서버에서 확인 후, Logout을 통해 유저가 사용중인 모든 브라우저에 Refresh Token이 삭제될 경우 Redis에서 삭제
    - [ ] TTL 시간까지 서버에서 동일한 Refresh Token 발급
- Logout API 구현
  - HttpOnly 쿠키일 경우, JavaScript로 열어볼 수 없기 때문에, 서버에서 직접적으로 쿠키 값을 지워주는 행위

## PR Checklist ✔️
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요 -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

## PR 타입 👏🏻
<!--- 하나 이상의 PR 타입을 선택해주세요 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

